### PR TITLE
option to block all replace

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,7 @@ github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9oc
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
-golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/gomodguard.go
+++ b/gomodguard.go
@@ -241,6 +241,7 @@ type Blocked struct {
 	Modules                BlockedModules  `yaml:"modules"`
 	Versions               BlockedVersions `yaml:"versions"`
 	LocalReplaceDirectives bool            `yaml:"local_replace_directives"`
+	Replace                bool            `yaml:"replace"`
 }
 
 // Configuration of gomodguard allow and block lists.
@@ -402,6 +403,12 @@ func (p *Processor) SetBlockedModules() { //nolint:gocognit
 
 		if blockVersionReason != nil && blockVersionReason.IsLintedModuleVersionBlocked(lintedModuleVersion) {
 			blockedModules[lintedModuleName] = append(blockedModules[lintedModuleName], fmt.Sprintf("%s %s", blockReasonInBlockedList, blockVersionReason.Message(lintedModuleVersion)))
+		}
+	}
+
+	if p.Config.Blocked.Replace {
+		for _, r := range p.Modfile.Replace {
+			p.Result = append(p.Result, Result{FileName: p.Modfile.Syntax.Name, LineNumber: r.Syntax.Start.Line, Reason: "replace directive not allowed"})
 		}
 	}
 


### PR DESCRIPTION
In addition to the existing block.local_replace_directives, this change
allows checking for the addition of any replace clauses.

Close golangci/golangci-lint#1812