### PR TITLE
update golangci-lint configuration

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v0.2.0
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.39

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,40 @@
 linters:
-  enable-all: true
-  disable:
-  - funlen
-  - gochecknoglobals
-  - lll
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    # - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace


### PR DESCRIPTION
* Update golangci-lint from v1.26 to v1.39
* Update golangci-lint-action from v0.2.0 to v2
* Avoid using enable-all per golangci-lint's recommendation, and
  instead enable all linters