### PR TITLE
Wrap long lines and suppress funlen warnings

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -28,6 +28,7 @@ var (
 )
 
 // Run the gomodguard linter. Returns the exit code to use.
+//nolint:funlen
 func Run() int {
 	var (
 		args           []string
@@ -43,7 +44,8 @@ func Run() int {
 	flag.BoolVar(&help, "help", false, "")
 	flag.BoolVar(&noTest, "n", false, "Don't lint test files")
 	flag.BoolVar(&noTest, "no-test", false, "")
-	flag.StringVar(&report, "r", "", "Report results to one of the following formats: checkstyle. A report file destination must also be specified")
+	flag.StringVar(&report, "r", "", "Report results to one of the following formats: checkstyle. "+
+		"A report file destination must also be specified")
 	flag.StringVar(&report, "report", "", "")
 	flag.StringVar(&reportFile, "f", "", "Report results to the specified file. A report type must also be specified")
 	flag.StringVar(&reportFile, "file", "", "")
@@ -202,7 +204,8 @@ func WriteCheckstyle(checkstyleFilePath string, results []Issue) error {
 
 	for i := range results {
 		file := check.EnsureFile(results[i].FileName)
-		file.AddError(checkstyle.NewError(results[i].LineNumber, 1, checkstyle.SeverityError, results[i].Reason, "gomodguard"))
+		file.AddError(checkstyle.NewError(results[i].LineNumber, 1, checkstyle.SeverityError, results[i].Reason,
+			"gomodguard"))
 	}
 
 	checkstyleXML := fmt.Sprintf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n%s", check.String())

--- a/gomodguard.go
+++ b/gomodguard.go
@@ -23,9 +23,12 @@ const (
 )
 
 var (
-	blockReasonNotInAllowedList         = "import of package `%s` is blocked because the module is not in the allowed modules list."
-	blockReasonInBlockedList            = "import of package `%s` is blocked because the module is in the blocked modules list."
-	blockReasonHasLocalReplaceDirective = "import of package `%s` is blocked because the module has a local replace directive."
+	blockReasonNotInAllowedList = "import of package `%s` is blocked because the module is not in the " +
+		"allowed modules list."
+	blockReasonInBlockedList = "import of package `%s` is blocked because the module is in the " +
+		"blocked modules list."
+	blockReasonHasLocalReplaceDirective = "import of package `%s` is blocked because the module has a " +
+		"local replace directive."
 )
 
 // BlockedVersion has a version constraint a reason why the the module version is blocked.
@@ -61,7 +64,8 @@ func (r *BlockedVersion) Message(lintedModuleVersion string) string {
 	msg := ""
 
 	// Add version contraint to message.
-	msg += fmt.Sprintf("version `%s` is blocked because it does not meet the version constraint `%s`.", lintedModuleVersion, r.Version)
+	msg += fmt.Sprintf("version `%s` is blocked because it does not meet the version constraint `%s`.",
+		lintedModuleVersion, r.Version)
 
 	if r.Reason == "" {
 		return msg
@@ -227,7 +231,8 @@ func (a *Allowed) IsAllowedModuleDomain(moduleName string) bool {
 	allowedDomains := a.Domains
 
 	for i := range allowedDomains {
-		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(moduleName)), strings.TrimSpace(strings.ToLower(allowedDomains[i]))) {
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(moduleName)),
+			strings.TrimSpace(strings.ToLower(allowedDomains[i]))) {
 			return true
 		}
 	}
@@ -363,7 +368,7 @@ func (p *Processor) addError(fileset *token.FileSet, pos token.Pos, reason strin
 //
 // It works by iterating over the dependant modules specified in the require
 // directive, checking if the module domain or full name is in the allowed list.
-func (p *Processor) SetBlockedModules() { //nolint:gocognit
+func (p *Processor) SetBlockedModules() { //nolint:gocognit,funlen
 	blockedModules := make(map[string][]string, len(p.Modfile.Require))
 	currentModuleName := p.Modfile.Module.Mod.Path
 	lintedModules := p.Modfile.Require
@@ -399,11 +404,13 @@ func (p *Processor) SetBlockedModules() { //nolint:gocognit
 		}
 
 		if blockModuleReason != nil && !blockModuleReason.IsCurrentModuleARecommendation(currentModuleName) {
-			blockedModules[lintedModuleName] = append(blockedModules[lintedModuleName], fmt.Sprintf("%s %s", blockReasonInBlockedList, blockModuleReason.Message()))
+			blockedModules[lintedModuleName] = append(blockedModules[lintedModuleName],
+				fmt.Sprintf("%s %s", blockReasonInBlockedList, blockModuleReason.Message()))
 		}
 
 		if blockVersionReason != nil && blockVersionReason.IsLintedModuleVersionBlocked(lintedModuleVersion) {
-			blockedModules[lintedModuleName] = append(blockedModules[lintedModuleName], fmt.Sprintf("%s %s", blockReasonInBlockedList, blockVersionReason.Message(lintedModuleVersion)))
+			blockedModules[lintedModuleName] = append(blockedModules[lintedModuleName],
+				fmt.Sprintf("%s %s", blockReasonInBlockedList, blockVersionReason.Message(lintedModuleVersion)))
 		}
 	}
 
@@ -417,7 +424,8 @@ func (p *Processor) SetBlockedModules() { //nolint:gocognit
 			replacedModuleNewVersion := strings.TrimSpace(replacedModules[i].New.Version)
 
 			if replacedModuleNewName != "" && replacedModuleNewVersion == "" {
-				blockedModules[replacedModuleOldName] = append(blockedModules[replacedModuleOldName], blockReasonHasLocalReplaceDirective)
+				blockedModules[replacedModuleOldName] = append(blockedModules[replacedModuleOldName],
+					blockReasonHasLocalReplaceDirective)
 			}
 		}
 	}

--- a/gomodguard_test.go
+++ b/gomodguard_test.go
@@ -47,13 +47,21 @@ func TestBlockedModuleIsAllowed(t *testing.T) {
 	}{
 		{
 			"blocked",
-			gomodguard.BlockedModule{Recommendations: []string{"github.com/somerecommended/module"}},
+			gomodguard.BlockedModule{
+				Recommendations: []string{
+					"github.com/somerecommended/module",
+				},
+			},
 			"github.com/ryancurrah/gomodguard",
 			false,
 		},
 		{
 			"allowed",
-			gomodguard.BlockedModule{Recommendations: []string{"github.com/ryancurrah/gomodguard"}},
+			gomodguard.BlockedModule{
+				Recommendations: []string{
+					"github.com/ryancurrah/gomodguard",
+				},
+			},
 			"github.com/ryancurrah/gomodguard",
 			true,
 		},
@@ -72,7 +80,8 @@ func TestBlockedModuleIsAllowed(t *testing.T) {
 func TestBlockedModuleMessage(t *testing.T) {
 	blockedWithNoRecommendation := "Some reason."
 	blockedWithRecommendation := "`github.com/somerecommended/module` is a recommended module. Some reason."
-	blockedWithRecommendations := "`github.com/somerecommended/module`, `github.com/someotherrecommended/module` and `github.com/someotherotherrecommended/module` are recommended modules. Some reason."
+	blockedWithRecommendations := "`github.com/somerecommended/module`, `github.com/someotherrecommended/module` " +
+		"and `github.com/someotherotherrecommended/module` are recommended modules. Some reason."
 
 	var tests = []struct {
 		testName          string
@@ -82,19 +91,34 @@ func TestBlockedModuleMessage(t *testing.T) {
 	}{
 		{
 			"blocked with no recommendation",
-			gomodguard.BlockedModule{Recommendations: []string{}, Reason: "Some reason."},
+			gomodguard.BlockedModule{
+				Recommendations: []string{},
+				Reason:          "Some reason.",
+			},
 			"github.com/ryancurrah/gomodguard",
 			blockedWithNoRecommendation,
 		},
 		{
 			"blocked with recommendation",
-			gomodguard.BlockedModule{Recommendations: []string{"github.com/somerecommended/module"}, Reason: "Some reason."},
+			gomodguard.BlockedModule{
+				Recommendations: []string{
+					"github.com/somerecommended/module",
+				},
+				Reason: "Some reason.",
+			},
 			"github.com/ryancurrah/gomodguard",
 			blockedWithRecommendation,
 		},
 		{
 			"blocked with multiple recommendations",
-			gomodguard.BlockedModule{Recommendations: []string{"github.com/somerecommended/module", "github.com/someotherrecommended/module", "github.com/someotherotherrecommended/module"}, Reason: "Some reason."},
+			gomodguard.BlockedModule{
+				Recommendations: []string{
+					"github.com/somerecommended/module",
+					"github.com/someotherrecommended/module",
+					"github.com/someotherotherrecommended/module",
+				},
+				Reason: "Some reason.",
+			},
 			"github.com/ryancurrah/gomodguard",
 			blockedWithRecommendations,
 		},
@@ -123,7 +147,11 @@ func TestBlockedModuleHasRecommendations(t *testing.T) {
 		},
 		{
 			"does have recommendations",
-			gomodguard.BlockedModule{Recommendations: []string{"github.com/ryancurrah/gomodguard"}},
+			gomodguard.BlockedModule{
+				Recommendations: []string{
+					"github.com/ryancurrah/gomodguard",
+				},
+			},
 			true,
 		},
 	}
@@ -146,7 +174,15 @@ func TestBlockedModulesGet(t *testing.T) {
 	}{
 		{
 			"get all blocked module names",
-			gomodguard.BlockedModules{{"github.com/someblocked/module": gomodguard.BlockedModule{Recommendations: []string{"github.com/ryancurrah/gomodguard"}}}},
+			gomodguard.BlockedModules{
+				{
+					"github.com/someblocked/module": gomodguard.BlockedModule{
+						Recommendations: []string{
+							"github.com/ryancurrah/gomodguard",
+						},
+					},
+				},
+			},
 			[]string{"github.com/someblocked/module"},
 		},
 	}
@@ -162,8 +198,10 @@ func TestBlockedModulesGet(t *testing.T) {
 }
 
 func TestBlockedVersionMessage(t *testing.T) {
-	blockedWithVersionConstraint := "version `1.0.0` is blocked because it does not meet the version constraint `1.0.0`. Some reason."
-	blockedWithVersionConstraintNoReason := "version `1.0.0` is blocked because it does not meet the version constraint `<= 1.0.0`."
+	blockedWithVersionConstraint := "version `1.0.0` is blocked because it does not meet the version constraint " +
+		"`1.0.0`. Some reason."
+	blockedWithVersionConstraintNoReason := "version `1.0.0` is blocked because it does not meet the version " +
+		"constraint `<= 1.0.0`."
 
 	var tests = []struct {
 		testName            string
@@ -173,7 +211,10 @@ func TestBlockedVersionMessage(t *testing.T) {
 	}{
 		{
 			"blocked with version constraint",
-			gomodguard.BlockedVersion{Version: "1.0.0", Reason: "Some reason."},
+			gomodguard.BlockedVersion{
+				Version: "1.0.0",
+				Reason:  "Some reason.",
+			},
 			"1.0.0",
 			blockedWithVersionConstraint,
 		},
@@ -205,14 +246,30 @@ func TestBlockedModulesGetBlockedModule(t *testing.T) {
 	}{
 		{
 			"blocked",
-			gomodguard.BlockedModules{{"github.com/someblocked/module": gomodguard.BlockedModule{Recommendations: []string{"github.com/someother/module"}}}},
+			gomodguard.BlockedModules{
+				{
+					"github.com/someblocked/module": gomodguard.BlockedModule{
+						Recommendations: []string{
+							"github.com/someother/module",
+						},
+					},
+				},
+			},
 			"github.com/ryancurrah/gomodguard",
 			"github.com/someblocked/module",
 			false,
 		},
 		{
 			"allowed",
-			gomodguard.BlockedModules{{"github.com/someblocked/module": gomodguard.BlockedModule{Recommendations: []string{"github.com/ryancurrah/gomodguard"}}}},
+			gomodguard.BlockedModules{
+				{
+					"github.com/someblocked/module": gomodguard.BlockedModule{
+						Recommendations: []string{
+							"github.com/ryancurrah/gomodguard",
+						},
+					},
+				},
+			},
 			"github.com/ryancurrah/gomodguard",
 			"github.com/someblocked/module",
 			true,
@@ -223,7 +280,8 @@ func TestBlockedModulesGetBlockedModule(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			blockedModule := tt.blockedModules.GetBlockReason(tt.lintedModuleName)
 			if blockedModule.IsCurrentModuleARecommendation(tt.currentModuleName) != tt.wantIsAllowed {
-				t.Errorf("got '%+v' want '%+v'", blockedModule.IsCurrentModuleARecommendation(tt.currentModuleName), tt.wantIsAllowed)
+				t.Errorf("got '%+v' want '%+v'", blockedModule.IsCurrentModuleARecommendation(tt.currentModuleName),
+					tt.wantIsAllowed)
 			}
 		})
 	}
@@ -337,17 +395,22 @@ func TestProcessorProcessFiles(t *testing.T) {
 		{
 			"module blocked because of recommendation",
 			gomodguard.Processor{Config: config, Modfile: processor.Modfile},
-			"blocked_example.go:9:1 import of package `github.com/uudashr/go-module` is blocked because the module is in the blocked modules list. `golang.org/x/mod` is a recommended module. `mod` is the official go.mod parser library.",
+			"blocked_example.go:9:1 import of package `github.com/uudashr/go-module` is blocked because the " +
+				"module is in the blocked modules list. `golang.org/x/mod` is a recommended module. `mod` " +
+				"is the official go.mod parser library.",
 		},
 		{
 			"module blocked because of version constraint",
 			gomodguard.Processor{Config: config, Modfile: processor.Modfile},
-			"blocked_example.go:7:1 import of package `github.com/mitchellh/go-homedir` is blocked because the module is in the blocked modules list. version `v1.1.0` is blocked because it does not meet the version constraint `<= 1.1.0`. testing if blocked version constraint works.",
+			"blocked_example.go:7:1 import of package `github.com/mitchellh/go-homedir` is blocked because " +
+				"the module is in the blocked modules list. version `v1.1.0` is blocked because it does not " +
+				"meet the version constraint `<= 1.1.0`. testing if blocked version constraint works.",
 		},
 		{
 			"module blocked because of local replace directive",
 			gomodguard.Processor{Config: config, Modfile: processor.Modfile},
-			"blocked_example.go:8:1 import of package `github.com/ryancurrah/gomodguard` is blocked because the module has a local replace directive.",
+			"blocked_example.go:8:1 import of package `github.com/ryancurrah/gomodguard` is blocked because " +
+				"the module has a local replace directive.",
 		},
 	}
 


### PR DESCRIPTION
#13 enabled some linters that weren't passing (sorry!), mostly due to long lines. This change wraps code to fix those lint failures.