### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,12 +2,26 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -16,30 +30,20 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.16
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
-
     - name: Build
-      run: go build -v .
+      run: make build
 
     - name: Test
       run: make test
 
     - name: Cover
-      run: |
-        make install-go-tools
-        make cover
+      run: make install-go-tools cover
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,28 @@
 name: golangci-lint
+
 on:
   push:
     tags:
       - v*
     branches:
       - master
+
   pull_request:
+    branches:
+      - master
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,5 +1,19 @@
 name: Snyk
+
 on: push
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,42 @@
 current_dir = $(shell pwd)
 
-.PHONEY: lint
+.PHONY: lint
 lint:
 	golangci-lint run ./...
 
-.PHONEY: build
+.PHONY: build
 build:
 	go build -o gomodguard cmd/gomodguard/main.go
 
-.PHONEY: run
+.PHONY: run
 run: build
 	./gomodguard
 
-.PHONEY: test
+.PHONY: test
 test:
 	go test -v -coverprofile coverage.out 
 
-.PHONEY: cover
+.PHONY: cover
 cover:
 	gocover-cobertura < coverage.out > coverage.xml
 
-.PHONEY: dockerrun
+.PHONY: dockerrun
 dockerrun: dockerbuild
 	docker run -v "${current_dir}/.gomodguard.yaml:/.gomodguard.yaml" ryancurrah/gomodguard:latest
 
-.PHONEY: release
+.PHONY: release
 release:
 	goreleaser --rm-dist
 
-.PHONEY: clean
+.PHONY: clean
 clean:
 	rm -rf dist/
 	rm -f gomodguard coverage.xml coverage.out
 
-.PHONEY: install-tools-mac
+.PHONY: install-tools-mac
 install-tools-mac:
 	brew install goreleaser/tap/goreleaser
 
-.PHONEY: install-go-tools
+.PHONY: install-go-tools
 install-go-tools:
 	go get github.com/t-yuki/gocover-cobertura

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryancurrah/gomodguard
 
-go 1.14
+go 1.16
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
* Reduce permissions for GITHUB_TOKEN issued during build
* Remove "go get" for downloading dependencies, as the build
  step will do this automatically for Go module projects
* Upgrade minimum Go version from 1.13 to 1.16
* Fix phony targets in Makefile (.PHONEY -> [.PHONY](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html))