### PR TITLE
Fully address #15 checksum mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	golang.org/x/mod v0.4.2
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+retract v1.2.1 // Originally tagged for commit hash that was subsequently removed, and replaced by another commit hash


### PR DESCRIPTION
See #15
Version v1.2.1 had been originally tagged for commit hash that was subsequently removed, and replaced by another commit hash.
Even though the window of time between the two release events was short, it was enough to get the go mod proxy confused, resulting in errors about mismatched checksums.

sum.golang.org is intended to guarantee that all Go users see the same code for a given module version. There's no way for it to know whether a change to a release was an intentional fix, a mistake, or an attack. Either way, reproducible builds are fundamental goal of the module ecosystem and users should be able to rely on things not changing invisibly.

If you use proxy.golang.org, it will serve you the same data for the version that sum.golang.org saw.

This adds the [retract directive](https://golang.org/ref/mod#go-mod-file-retract) to the `go.mod` file for ryancurrah/gomodguard so retracted versions will be hidden from the version list printed by `go list -m -versions` unless the `-retracted` flag is used. Retracted versions are excluded when resolving version queries like `@>=v1.2.3` or `@latest`.

This will also prevent consumers of this library that run `go mod verify` and `go mod download -x` from looking at the bad checksum from the older v1.2.1 release after a newer version is published and depended on.

Signed-off-by: Steve Coffman <steve@khanacademy.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/errors/83)
<!-- Reviewable:end -->
