### PR TITLE
wrap in directory, format overrides

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,14 @@ archives:
     {{- if eq .Arch "amd64" }}x86_64
     {{- else if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
+  wrap_in_directory: true
+  format_overrides:
+    - goos: windows
+      format: zip
+    - goos: darwin
+      format: tar.xz
+    - goos: linux
+      format: tar.xz
 checksum:
   name_template: 'checksums.txt'
 dockers:


### PR DESCRIPTION
This patch will place archive files inside of a folder such as:
* `gomodguard_Windows_x86_64/gomodguard.exe`
* `gomodguard_Darwin_arm64/gomodguard`
* These will also include the `LICENSE` and `README.md` files.

On Windows, it will now use `.zip` file format and will use `.tar.xz` to achieve a better compression ratio on Darwin and Linux.  Tar and gzip/xz do not ship with Windows, so zip is preferred on this platform.

Tested with: `goreleaser release --snapshot --clean`