### PR TITLE
refactor: use `encoding/xml` instead of `go-xmlfmt/xmlfmt`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
-	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7r
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-xmlfmt/xmlfmt v1.1.2 h1:Nea7b4icn8s57fTx1M5AI4qQT5HEM3rVUO8MuE6g80U=
-github.com/go-xmlfmt/xmlfmt v1.1.2/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9ocOS/xlSptM1N3BbrA6/kmaep5ggwaIA=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,15 +1,16 @@
 package cli
 
 import (
+	"encoding/xml"
 	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
-	"github.com/go-xmlfmt/xmlfmt"
 	"github.com/mitchellh/go-homedir"
 	"github.com/phayes/checkstyle"
 	"github.com/ryancurrah/gomodguard"
@@ -171,9 +172,15 @@ func WriteCheckstyle(checkstyleFilePath string, results []gomodguard.Issue) erro
 			"gomodguard"))
 	}
 
-	checkstyleXML := fmt.Sprintf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n%s", check.String())
+	body, err := xml.MarshalIndent(check, "", "  ")
+	if err != nil {
+		return err
+	}
 
-	err := os.WriteFile(checkstyleFilePath, []byte(xmlfmt.FormatXML(checkstyleXML, "", "  ")), 0644) //nolint:gosec
+	header := []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+	checkstyleXML := slices.Concat([]byte{'\n'}, header, []byte{'\n'}, body)
+
+	err = os.WriteFile(checkstyleFilePath, checkstyleXML, 0644) //nolint:gosec
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ryancurrah/gomodguard"
 	"github.com/ryancurrah/gomodguard/internal/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -25,4 +28,41 @@ func TestCmdRun(t *testing.T) {
 	if exitCode != wantExitCode {
 		t.Errorf("got exit code '%d' want '%d'", exitCode, wantExitCode)
 	}
+}
+
+func TestWriteCheckstyle(t *testing.T) {
+	outFile, err := os.CreateTemp(t.TempDir(), "checkstyle-*.xml")
+	require.NoError(t, err)
+	defer outFile.Close()
+
+	issues := []gomodguard.Issue{
+		{
+			FileName:   "first.go",
+			LineNumber: 10,
+			Reason:     "first test reason",
+		},
+		{
+			FileName:   "second.go",
+			LineNumber: 20,
+			Reason:     "second test reason",
+		},
+	}
+
+	err = cli.WriteCheckstyle(outFile.Name(), issues)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(outFile.Name())
+	require.NoError(t, err)
+
+	want := `
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="1.0.0">
+  <file name="first.go">
+    <error line="10" column="1" severity="error" message="first test reason" source="gomodguard"></error>
+  </file>
+  <file name="second.go">
+    <error line="20" column="1" severity="error" message="second test reason" source="gomodguard"></error>
+  </file>
+</checkstyle>`
+	assert.Equal(t, want, string(got))
 }


### PR DESCRIPTION
The PR proposes to refactor the `WriteCheckstyle` implementation, and use `xml.MarshalIndent` instead of `go-xmlfmt/xmlfmt.FormatXML`. This allows dropping the `github.com/go-xmlfmt/xmlfmt` to minimize external dependencies and simplify maintenance. There is no need for an external dependency when we can utilize the standard library.