### PR TITLE
chore(go.mod): update gopkg.in/yaml.v2 to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Results can be exported to different report formats. Which can be imported into 
 ```yaml
 allowed:
   modules:                                                      # List of allowed modules
-    - gopkg.in/yaml.v2
+    - gopkg.in/yaml.v3
     - github.com/go-xmlfmt/xmlfmt
     - github.com/phayes/checkstyle
     - github.com/mitchellh/go-homedir
@@ -88,7 +88,7 @@ Flags:
 ```
 ╰─ ./gomodguard -r checkstyle -f gomodguard-checkstyle.xml ./...
 
-info: allowed modules, [gopkg.in/yaml.v2 github.com/go-xmlfmt/xmlfmt github.com/phayes/checkstyle github.com/mitchellh/go-homedir]
+info: allowed modules, [gopkg.in/yaml.v3 github.com/go-xmlfmt/xmlfmt github.com/phayes/checkstyle github.com/mitchellh/go-homedir]
 info: allowed module domains, [golang.org]
 info: blocked modules, [github.com/uudashr/go-module]
 info: found `2` blocked modules in the go.mod file, [github.com/gofrs/uuid github.com/uudashr/go-module]

--- a/_example/allOptions/.gomodguard.yaml
+++ b/_example/allOptions/.gomodguard.yaml
@@ -1,6 +1,6 @@
 allowed:
   modules:                                                      # List of allowed modules
-    - gopkg.in/yaml.v2
+    - gopkg.in/yaml.v3
     - github.com/go-xmlfmt/xmlfmt
     - github.com/Masterminds/semver
     - github.com/ryancurrah/gomodguard

--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,12 @@ require (
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/mod v0.22.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 retract v1.2.1 // Originally tagged for commit hash that was subsequently removed, and replaced by another commit hash

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,5 @@ golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,7 +14,7 @@ import (
 	"github.com/phayes/checkstyle"
 	"github.com/ryancurrah/gomodguard"
 	"github.com/ryancurrah/gomodguard/internal/filesearch"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/processor_internal_test.go
+++ b/processor_internal_test.go
@@ -177,7 +177,7 @@ func TestProcessorSetBlockedModulesWithAllowList(t *testing.T) {
 	config := &Configuration{
 		Allowed: Allowed{
 			Modules: []string{
-				"gopkg.in/yaml.v2",
+				"gopkg.in/yaml.v3",
 				"github.com/go-xmlfmt/xmlfmt",
 				"github.com/Masterminds/semver/v3",
 				"github.com/ryancurrah/gomodguard",
@@ -223,8 +223,8 @@ func TestProcessorSetBlockedModulesWithAllowList(t *testing.T) {
 		Require: []*modfile.Require{
 			{
 				Mod: module.Version{
-					Path:    "gopkg.in/yaml.v2",
-					Version: "v2.4.0",
+					Path:    "gopkg.in/yaml.v3",
+					Version: "v3.0.1",
 				},
 			},
 			{

--- a/processor_test.go
+++ b/processor_test.go
@@ -38,7 +38,7 @@ func TestProcessorProcessFiles(t *testing.T) { //nolint:funlen
 	config := &gomodguard.Configuration{
 		Allowed: gomodguard.Allowed{
 			Modules: []string{
-				"gopkg.in/yaml.v2",
+				"gopkg.in/yaml.v3",
 				"github.com/go-xmlfmt/xmlfmt",
 				"github.com/Masterminds/semver/v3",
 				"github.com/ryancurrah/gomodguard",


### PR DESCRIPTION
The PR removes the dependency on `gopkg.in/yaml.v2` in favor of `gopkg.in/yaml.v3`.

This update was done manually because [@dependabot](https://github.com/apps/dependabot) cannot bump major versions.
