### PR TITLE
chore: downgrade minimum Go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@
 linters:
   enable-all: true
   disable:
+    - tenv
     - lll
     - gomodguard
     - gochecknoglobals

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryancurrah/gomodguard
 
-go 1.24
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/processor_test.go
+++ b/processor_test.go
@@ -25,9 +25,19 @@ func TestProcessorNewProcessor(t *testing.T) {
 }
 
 func TestProcessorProcessFiles(t *testing.T) { //nolint:funlen
-	t.Chdir("_example/allOptions")
+	backupWd, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+	}
 
-	cwd, err := os.Getwd()
+	defer func() { _ = os.Chdir(backupWd) }()
+
+	err = os.Chdir("_example/allOptions")
+	if err != nil {
+		t.Error(err)
+	}
+
+	wd, err := os.Getwd()
 	if err != nil {
 		t.Error(err)
 	}
@@ -76,7 +86,7 @@ func TestProcessorProcessFiles(t *testing.T) { //nolint:funlen
 		t.Error(err)
 	}
 
-	filteredFiles := filesearch.Find(cwd, false, []string{"./..."})
+	filteredFiles := filesearch.Find(wd, false, []string{"./..."})
 
 	var tests = []struct {
 		testName   string


### PR DESCRIPTION
Since go1.21, the Go version used inside the `go.mod` is the minimum Go version and it's a hard requirement.

Inside golangci-lint, we need to be compatible with go1.23 as we support go1.23 and go1.24 to compile.

