### PR TITLE
feat: replace allowed domains with prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Allow and block list linter for direct Go module dependencies. This is useful fo
 
 Allowed and blocked modules are defined in a `./.gomodguard.yaml` or `~/.gomodguard.yaml` file. 
 
-Modules can be allowed by module or domain name. When allowed modules are specified any modules not in the allowed configuration are blocked.
+Modules can be allowed by module or prefix name. When allowed modules are specified any modules not in the allowed configuration are blocked.
 
-If no allowed modules or domains are specified then all modules are allowed except for blocked ones.
+If no allowed modules or module prefixes are specified then all modules are allowed except for blocked ones.
 
 The linter looks for blocked modules in `go.mod` and searches for imported packages where the imported packages module is blocked. Indirect modules are not considered.
 
@@ -41,8 +41,11 @@ allowed:
     - github.com/go-xmlfmt/xmlfmt
     - github.com/phayes/checkstyle
     - github.com/mitchellh/go-homedir
-  domains:                                                      # List of allowed module domains
-    - golang.org
+    - github.com/confluentinc/confluent-kafka-go/v2   # Allow v2 only
+  prefixes:                                                     # List of allowed module prefixes (Replaced domains which is now deprecated)
+    - golang.org                  # Allow all golang.org modules
+    - github.com/kubernetes       # Allow all Kubernetes modules
+    - github.com/apache/arrow-go  # Allow all Apache Arrow module major versions
 
 blocked:
   modules:                                                      # List of blocked modules
@@ -89,7 +92,7 @@ Flags:
 ╰─ ./gomodguard -r checkstyle -f gomodguard-checkstyle.xml ./...
 
 info: allowed modules, [gopkg.in/yaml.v3 github.com/go-xmlfmt/xmlfmt github.com/phayes/checkstyle github.com/mitchellh/go-homedir]
-info: allowed module domains, [golang.org]
+info: allowed module prefixes, [golang.org]
 info: blocked modules, [github.com/uudashr/go-module]
 info: found `2` blocked modules in the go.mod file, [github.com/gofrs/uuid github.com/uudashr/go-module]
 blocked_example.go:6: import of package `github.com/gofrs/uuid` is blocked because the module is not in the allowed modules list.

--- a/_example/allOptions/.gomodguard.yaml
+++ b/_example/allOptions/.gomodguard.yaml
@@ -4,7 +4,7 @@ allowed:
     - github.com/go-xmlfmt/xmlfmt
     - github.com/Masterminds/semver
     - github.com/ryancurrah/gomodguard
-  domains:                                                      # List of allowed module domains
+  prefixes:                                                      # List of allowed module prefixes
     - golang.org
 
 blocked:

--- a/_example/indirectDep/.gomodguard.yaml
+++ b/_example/indirectDep/.gomodguard.yaml
@@ -4,7 +4,7 @@ allowed:
     - github.com/go-xmlfmt/xmlfmt
     - github.com/Masterminds/semver
     - github.com/ryancurrah/gomodguard
-  domains:                                                      # List of allowed module domains
+  prefixes:                                                      # List of allowed module prefixes
     - golang.org
 
 blocked:

--- a/_example/invalidConstraint/.gomodguard.yaml
+++ b/_example/invalidConstraint/.gomodguard.yaml
@@ -1,7 +1,7 @@
 allowed:
   modules:
     - github.com/pborman/uuid
-  domains:
+  prefixes:
     - golang.org
 blocked:
   modules:
@@ -24,5 +24,5 @@ blocked:
         version: "!= 1.3.0"
     - github.com/gin-gonic/gin:
         version: "== 1.9.1"
-  domains: []
+  prefixes: []
  

--- a/allowed.go
+++ b/allowed.go
@@ -1,12 +1,16 @@
 package gomodguard
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // Allowed is a list of modules and module
-// domains that are allowed to be used.
+// prefixes that are allowed to be used.
 type Allowed struct {
-	Modules []string `yaml:"modules"`
-	Domains []string `yaml:"domains"`
+	Modules  []string `yaml:"modules"`
+	Domains  []string `yaml:"domains"`
+	Prefixes []string `yaml:"prefixes"`
 }
 
 // IsAllowedModule returns true if the given module
@@ -23,14 +27,17 @@ func (a *Allowed) IsAllowedModule(moduleName string) bool {
 	return false
 }
 
-// IsAllowedModuleDomain returns true if the given modules domain is
-// in the allowed module domains list.
-func (a *Allowed) IsAllowedModuleDomain(moduleName string) bool {
-	allowedDomains := a.Domains
+// IsAllowedModulePrefix returns true if the given modules prefix is
+// in the allowed module prefixes list.
+func (a *Allowed) IsAllowedModulePrefix(moduleName string) bool {
+	allowedPrefixes := make([]string, 0, len(a.Prefixes)+len(a.Domains))
+	allowedPrefixes = append(allowedPrefixes, a.Prefixes...)
+	allowedPrefixes = append(allowedPrefixes, a.Domains...)
+	allowedPrefixes = slices.Compact(allowedPrefixes)
 
-	for i := range allowedDomains {
+	for i := range allowedPrefixes {
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(moduleName)),
-			strings.TrimSpace(strings.ToLower(allowedDomains[i]))) {
+			strings.TrimSpace(strings.ToLower(allowedPrefixes[i]))) {
 			return true
 		}
 	}

--- a/allowed_test.go
+++ b/allowed_test.go
@@ -38,16 +38,16 @@ func TestAllowedIsAllowedModule(t *testing.T) {
 	}
 }
 
-func TestAllowedIsAllowedModuleDomain(t *testing.T) {
+func TestAllowedIsAllowedModulePrefix(t *testing.T) {
 	var tests = []struct {
 		testName                  string
 		allowedModules            gomodguard.Allowed
 		lintedModuleName          string
-		wantIsAllowedModuleDomain bool
+		wantIsAllowedModulePrefix bool
 	}{
 		{
 			"module is allowed",
-			gomodguard.Allowed{Domains: []string{"github.com"}},
+			gomodguard.Allowed{Prefixes: []string{"github.com"}},
 			"github.com/someallowed/module",
 			true,
 		},
@@ -61,9 +61,9 @@ func TestAllowedIsAllowedModuleDomain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			isAllowedModuleDomain := tt.allowedModules.IsAllowedModuleDomain(tt.lintedModuleName)
-			if !reflect.DeepEqual(isAllowedModuleDomain, tt.wantIsAllowedModuleDomain) {
-				t.Errorf("got '%v' want '%v'", isAllowedModuleDomain, tt.wantIsAllowedModuleDomain)
+			isAllowedModulePrefix := tt.allowedModules.IsAllowedModulePrefix(tt.lintedModuleName)
+			if !reflect.DeepEqual(isAllowedModulePrefix, tt.wantIsAllowedModulePrefix) {
+				t.Errorf("got '%v' want '%v'", isAllowedModulePrefix, tt.wantIsAllowedModulePrefix)
 			}
 		})
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -94,7 +94,13 @@ func Run() int {
 	}
 
 	logger.Printf("info: allowed modules, %+v", config.Allowed.Modules)
-	logger.Printf("info: allowed module domains, %+v", config.Allowed.Domains)
+	logger.Printf("info: allowed module prefixes, %+v", config.Allowed.Prefixes)
+
+	if len(config.Allowed.Domains) > 0 {
+		logger.Printf("info: allowed module domains, %+v", config.Allowed.Domains)
+		logger.Printf("warning: 'domains' is deprecated, please use 'prefixes' instead")
+	}
+
 	logger.Printf("info: blocked modules, %+v", config.Blocked.Modules.Get())
 	logger.Printf("info: blocked modules with version constraints, %+v", config.Blocked.Versions.Get())
 

--- a/processor.go
+++ b/processor.go
@@ -94,7 +94,7 @@ func (p *Processor) ProcessFiles(filenames []string) (issues []Issue) {
 // the go.mod file of the module that is being linted.
 //
 // It works by iterating over the dependant modules specified in the require
-// directive, checking if the module domain or full name is in the allowed list.
+// directive, checking if the module prefix or full name is in the allowed list.
 func (p *Processor) SetBlockedModules() { //nolint:funlen
 	blockedModules := make(map[string][]string, len(p.Modfile.Require))
 	currentModuleName := p.Modfile.Module.Mod.Path
@@ -108,9 +108,9 @@ func (p *Processor) SetBlockedModules() { //nolint:funlen
 		var isAllowed bool
 
 		switch {
-		case len(p.Config.Allowed.Modules) == 0 && len(p.Config.Allowed.Domains) == 0:
+		case len(p.Config.Allowed.Modules) == 0 && len(p.Config.Allowed.Prefixes) == 0 && len(p.Config.Allowed.Domains) == 0:
 			isAllowed = true
-		case p.Config.Allowed.IsAllowedModuleDomain(lintedModuleName):
+		case p.Config.Allowed.IsAllowedModulePrefix(lintedModuleName):
 			isAllowed = true
 		case p.Config.Allowed.IsAllowedModule(lintedModuleName):
 			isAllowed = true

--- a/processor_internal_test.go
+++ b/processor_internal_test.go
@@ -182,7 +182,7 @@ func TestProcessorSetBlockedModulesWithAllowList(t *testing.T) {
 				"github.com/Masterminds/semver/v3",
 				"github.com/ryancurrah/gomodguard",
 			},
-			Domains: []string{
+			Prefixes: []string{
 				"golang.org",
 			},
 		},
@@ -403,7 +403,7 @@ func TestProcessorSetBlockedModulesWithIndirectDependency(t *testing.T) {
 						"github.com/Masterminds/semver/v3",
 						"github.com/ryancurrah/gomodguard",
 					},
-					Domains: []string{
+					Prefixes: []string{
 						"golang.org",
 					},
 				},
@@ -452,7 +452,7 @@ func TestProcessorSetBlockedModulesWithIndirectDependency(t *testing.T) {
 						"github.com/Masterminds/semver/v3",
 						"github.com/ryancurrah/gomodguard",
 					},
-					Domains: []string{
+					Prefixes: []string{
 						"golang.org",
 					},
 				},

--- a/processor_test.go
+++ b/processor_test.go
@@ -39,7 +39,7 @@ func TestProcessorProcessFiles(t *testing.T) { //nolint:funlen
 				"github.com/Masterminds/semver/v3",
 				"github.com/ryancurrah/gomodguard",
 			},
-			Domains: []string{
+			Prefixes: []string{
 				"golang.org",
 			},
 		},


### PR DESCRIPTION
This introduces a new `prefixes` configuration option under `allowed` to replace the `domains` option, which is now deprecated. The term `prefixes` is more accurate since the matching logic checks for module prefixes rather than strict domain names.

The `domains` configuration is still supported for backward compatibility but will emit a deprecation warning when used. Both configurations are combined and treated as prefixes under the hood.

Changes include:
- Renaming internal methods from `IsAllowedModuleDomain` to `IsAllowedModulePrefix`
- Adding a deprecation warning in the CLI for `domains`
- Updating the example `.gomodguard.yaml` files
- Updating documentation in the README
- Updating unit tests to reflect the new option