### PR TITLE
chore(deps): switch from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Results can be exported to different report formats. Which can be imported into 
 ```yaml
 allowed:
   modules:                                                      # List of allowed modules
-    - gopkg.in/yaml.v3
+    - go.yaml.in/yaml/v3
     - github.com/go-xmlfmt/xmlfmt
     - github.com/phayes/checkstyle
     - github.com/mitchellh/go-homedir
@@ -91,7 +91,7 @@ Flags:
 ```
 ╰─ ./gomodguard -r checkstyle -f gomodguard-checkstyle.xml ./...
 
-info: allowed modules, [gopkg.in/yaml.v3 github.com/go-xmlfmt/xmlfmt github.com/phayes/checkstyle github.com/mitchellh/go-homedir]
+info: allowed modules, [go.yaml.in/yaml/v3 github.com/go-xmlfmt/xmlfmt github.com/phayes/checkstyle github.com/mitchellh/go-homedir]
 info: allowed module prefixes, [golang.org]
 info: blocked modules, [github.com/uudashr/go-module]
 info: found `2` blocked modules in the go.mod file, [github.com/gofrs/uuid github.com/uudashr/go-module]

--- a/_example/allOptions/.gomodguard.yaml
+++ b/_example/allOptions/.gomodguard.yaml
@@ -1,6 +1,6 @@
 allowed:
   modules:                                                      # List of allowed modules
-    - gopkg.in/yaml.v3
+    - go.yaml.in/yaml/v3
     - github.com/go-xmlfmt/xmlfmt
     - github.com/Masterminds/semver
     - github.com/ryancurrah/gomodguard

--- a/_example/indirectDep/.gomodguard.yaml
+++ b/_example/indirectDep/.gomodguard.yaml
@@ -1,6 +1,6 @@
 allowed:
   modules:                                                      # List of allowed modules
-    - gopkg.in/yaml.v3
+    - go.yaml.in/yaml/v3
     - github.com/go-xmlfmt/xmlfmt
     - github.com/Masterminds/semver
     - github.com/ryancurrah/gomodguard

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,14 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d
 	github.com/stretchr/testify v1.11.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/mod v0.34.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 retract v1.2.1 // Originally tagged for commit hash that was subsequently removed, and replaced by another commit hash

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,7 +15,7 @@ import (
 	"github.com/phayes/checkstyle"
 	"github.com/ryancurrah/gomodguard"
 	"github.com/ryancurrah/gomodguard/internal/filesearch"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/processor_internal_test.go
+++ b/processor_internal_test.go
@@ -177,7 +177,7 @@ func TestProcessorSetBlockedModulesWithAllowList(t *testing.T) {
 	config := &Configuration{
 		Allowed: Allowed{
 			Modules: []string{
-				"gopkg.in/yaml.v3",
+				"go.yaml.in/yaml/v3",
 				"github.com/go-xmlfmt/xmlfmt",
 				"github.com/Masterminds/semver/v3",
 				"github.com/ryancurrah/gomodguard",
@@ -223,8 +223,8 @@ func TestProcessorSetBlockedModulesWithAllowList(t *testing.T) {
 		Require: []*modfile.Require{
 			{
 				Mod: module.Version{
-					Path:    "gopkg.in/yaml.v3",
-					Version: "v3.0.1",
+					Path:    "go.yaml.in/yaml/v3",
+					Version: "v3.0.4",
 				},
 			},
 			{
@@ -398,7 +398,7 @@ func TestProcessorSetBlockedModulesWithIndirectDependency(t *testing.T) {
 			config: &Configuration{
 				Allowed: Allowed{
 					Modules: []string{
-						"gopkg.in/yaml.v3",
+						"go.yaml.in/yaml/v3",
 						"github.com/go-xmlfmt/xmlfmt",
 						"github.com/Masterminds/semver/v3",
 						"github.com/ryancurrah/gomodguard",
@@ -447,7 +447,7 @@ func TestProcessorSetBlockedModulesWithIndirectDependency(t *testing.T) {
 			config: &Configuration{
 				Allowed: Allowed{
 					Modules: []string{
-						"gopkg.in/yaml.v3",
+						"go.yaml.in/yaml/v3",
 						"github.com/go-xmlfmt/xmlfmt",
 						"github.com/Masterminds/semver/v3",
 						"github.com/ryancurrah/gomodguard",

--- a/processor_test.go
+++ b/processor_test.go
@@ -34,7 +34,7 @@ func TestProcessorProcessFiles(t *testing.T) { //nolint:funlen
 	config := &gomodguard.Configuration{
 		Allowed: gomodguard.Allowed{
 			Modules: []string{
-				"gopkg.in/yaml.v3",
+				"go.yaml.in/yaml/v3",
 				"github.com/go-xmlfmt/xmlfmt",
 				"github.com/Masterminds/semver/v3",
 				"github.com/ryancurrah/gomodguard",


### PR DESCRIPTION
gopkg.in/yaml.v3 is unmaintained, ref https://github.com/yaml/go-yaml#project-status

- 3.0.1..3.0.2 diff (3.0.1 are identical): https://gist.github.com/scop/6ec72debf62a9603cff9dc97e6814ddd
- changes after that as usual from https://github.com/yaml/go-yaml/tags

Remaining indirect dep comes from testify, https://github.com/stretchr/testify/pull/1772