### PR TITLE
fix: remove replace directive so go install works for v2 CLI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,3 +28,8 @@ linters:
       rules:
         - name: package-comments
           disabled: true
+  exclusions:
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ lint:
 	golangci-lint run ./...
 	cd cmd/gomodguard && golangci-lint run ./...
 
+.PHONY: tidy
+tidy:
+	go mod tidy
+	cd cmd/gomodguard && go mod tidy
+
 .PHONY: build
 build:
 	cd cmd/gomodguard && go build -o "$$(go env GOPATH)/bin/gomodguard" main.go
@@ -47,11 +52,20 @@ clean:
 
 .PHONY: tag
 tag:
-	@current=$$(git tag --sort=-v:refname --list 'v*' | head -n1 || echo "none"); \
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "error: working tree not clean"; exit 1; \
+	fi; \
+	current=$$(git tag --sort=-v:refname --list 'v*' | head -n1 || echo "none"); \
 	read -p "Current version: $$current. Enter new version: " version; \
+	if [ -z "$$version" ]; then echo "error: version required"; exit 1; fi; \
+	branch=$$(git branch --show-current); \
 	git tag "$$version" && \
+	git push origin "$$version" && \
+	(cd cmd/gomodguard && GOWORK=off go get "github.com/ryancurrah/gomodguard/v2@$$version" && GOWORK=off go mod tidy) && \
+	git add cmd/gomodguard/go.mod cmd/gomodguard/go.sum && \
+	git commit -m "chore: bump library to $$version" && \
 	git tag "cmd/gomodguard/$$version" && \
-	git push origin "$$version" "cmd/gomodguard/$$version"
+	git push origin "$$branch" "cmd/gomodguard/$$version"
 
 .PHONY: install-mac-tools
 install-tools-mac:

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Resulting checkstyle file
 ## Install
 
 ```
-go install github.com/ryancurrah/gomodguard/v2/cmd/gomodguard@latest
+go install github.com/ryancurrah/gomodguard/cmd/gomodguard/v2@latest
 ```
 
 ## Develop
@@ -211,6 +211,8 @@ git clone https://github.com/ryancurrah/gomodguard.git && cd gomodguard/cmd/gomo
 
 go build -o gomodguard main.go
 ```
+
+The repository is a multi-module workspace: the library lives at the root and the CLI lives under `cmd/gomodguard`. A `go.work` file at the repo root wires them together so local CLI builds pick up local library changes without needing a `replace` directive in `cmd/gomodguard/go.mod`.
 
 ## License
 

--- a/cmd/gomodguard/go.mod
+++ b/cmd/gomodguard/go.mod
@@ -2,13 +2,11 @@ module github.com/ryancurrah/gomodguard/cmd/gomodguard/v2
 
 go 1.25.0
 
-replace github.com/ryancurrah/gomodguard/v2 => ../../
-
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d
-	github.com/ryancurrah/gomodguard/v2 v2.0.1
+	github.com/ryancurrah/gomodguard/v2 v2.1.0
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 )
@@ -16,7 +14,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/mod v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/cmd/gomodguard/go.sum
+++ b/cmd/gomodguard/go.sum
@@ -8,12 +8,14 @@ github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9oc
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ryancurrah/gomodguard/v2 v2.1.0 h1:iIIARHe7Fsp10LY5utfMmYA++hkVuKsMFGDzxnVcijU=
+github.com/ryancurrah/gomodguard/v2 v2.1.0/go.mod h1:ryDqr6as4otkNbUp/U0m7zAsxGpwcJ9NtL6mvy9Zzdw=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
 go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
-golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
-golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: auto

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.25.0
+
+use (
+	.
+	./cmd/gomodguard
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
+golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=


### PR DESCRIPTION
The replace directive in cmd/gomodguard/go.mod made `go install
github.com/ryancurrah/gomodguard/cmd/gomodguard/v2@latest` fail because
Go rejects modules whose go.mod contains replace directives. Replace the
local-development convenience with a go.work file at the repo root, fix
the install path in the README, and bump the library require to v2.1.0.

Closes #99