### PR TITLE
chore: open cmd library bump as PR in tag target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,25 @@ tag:
 	current=$$(git tag --sort=-v:refname --list 'v*' | head -n1 || echo "none"); \
 	read -p "Current version: $$current. Enter new version: " version; \
 	if [ -z "$$version" ]; then echo "error: version required"; exit 1; fi; \
-	branch=$$(git branch --show-current); \
+	bump_branch="bump-library-to-$$version"; \
 	git tag "$$version" && \
 	git push origin "$$version" && \
+	git checkout -b "$$bump_branch" && \
 	(cd cmd/gomodguard && GOWORK=off go get "github.com/ryancurrah/gomodguard/v2@$$version" && GOWORK=off go mod tidy) && \
 	git add cmd/gomodguard/go.mod cmd/gomodguard/go.sum && \
 	git commit -m "chore: bump library to $$version" && \
 	git tag "cmd/gomodguard/$$version" && \
-	git push origin "$$branch" "cmd/gomodguard/$$version"
+	git push -u origin "$$bump_branch" "cmd/gomodguard/$$version" && \
+	gh pr create --title "chore: bump library to $$version" --body "Required by cmd/gomodguard/$$version release." && \
+	echo "waiting for PR to merge..." && \
+	while :; do \
+		state=$$(gh pr view --json state -q .state); \
+		if [ "$$state" = "MERGED" ]; then break; fi; \
+		if [ "$$state" = "CLOSED" ]; then echo "error: PR closed without merge"; exit 1; fi; \
+		sleep 30; \
+	done && \
+	git checkout main && git pull --ff-only origin main && \
+	git branch -D "$$bump_branch"
 
 .PHONY: install-mac-tools
 install-tools-mac:

--- a/cmd/gomodguard/go.mod
+++ b/cmd/gomodguard/go.mod
@@ -3,10 +3,10 @@ module github.com/ryancurrah/gomodguard/cmd/gomodguard/v2
 go 1.25.0
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d
-	github.com/ryancurrah/gomodguard/v2 v2.1.0
+	github.com/ryancurrah/gomodguard/v2 v2.1.1
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 )

--- a/cmd/gomodguard/go.sum
+++ b/cmd/gomodguard/go.sum
@@ -1,5 +1,5 @@
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -8,8 +8,8 @@ github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9oc
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ryancurrah/gomodguard/v2 v2.1.0 h1:iIIARHe7Fsp10LY5utfMmYA++hkVuKsMFGDzxnVcijU=
-github.com/ryancurrah/gomodguard/v2 v2.1.0/go.mod h1:ryDqr6as4otkNbUp/U0m7zAsxGpwcJ9NtL6mvy9Zzdw=
+github.com/ryancurrah/gomodguard/v2 v2.1.1 h1:cGZsDHcDDufRmt2GJLq+OJ2QK+QPmdnNWs1Ec2nItqk=
+github.com/ryancurrah/gomodguard/v2 v2.1.1/go.mod h1:CQicdLGatWMxLX53JzoBjYlsNZhHbmLv2AVa0s2aivU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=


### PR DESCRIPTION
Direct push to main fails when branch protection requires PRs. The tag
target now creates a bump-library-to-vX.Y.Z branch, bumps
cmd/gomodguard/go.mod to require the new library tag (via go get + go
mod tidy), commits the resulting go.mod/go.sum changes, tags the cmd
module on that commit, opens a PR via gh, polls until the PR merges,
then fast-forwards main and drops the local branch.
