### PR TITLE
chore(release): migrate to goreleaser v2 schema and publish multi-arc…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           go-version: stable
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/cmd/gomodguard/.goreleaser.yml
+++ b/cmd/gomodguard/.goreleaser.yml
@@ -13,25 +13,28 @@ archives:
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
       - goos: darwin
-        format: tar.xz
+        formats: ["tar.xz"]
       - goos: linux
-        format: tar.xz
+        formats: ["tar.xz"]
 checksum:
   name_template: "checksums.txt"
-dockers:
-  - goos: linux
-    goarch: amd64
-    image_templates:
-      - "ryancurrah/gomodguard:latest"
-      - "ryancurrah/gomodguard:{{.Tag}}"
-    skip_push: false
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
+dockers_v2:
+  - dockerfile: Dockerfile
+    images:
+      - ryancurrah/gomodguard
+    tags:
+      - "latest"
+      - "v{{ replace .Version \"cmd/gomodguard/v\" \"\" }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    flags:
+      - --pull
+    labels:
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.name": "{{ .ProjectName }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.source": "{{ .GitURL }}"

--- a/cmd/gomodguard/Dockerfile
+++ b/cmd/gomodguard/Dockerfile
@@ -1,6 +1,5 @@
-# ---- App container
-FROM golang:alpine
-WORKDIR /
-RUN apk --no-cache add ca-certificates
-COPY gomodguard /gomodguard
-ENTRYPOINT ./gomodguard
+FROM gcr.io/distroless/static
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/gomodguard /gomodguard
+ENTRYPOINT ["/gomodguard"]


### PR DESCRIPTION
…h images

- archives.format_overrides: deprecated `format` → `formats` list
- dockers → dockers_v2 building linux/amd64 + linux/arm64 in a single buildx invocation; tag template uses `replace` to strip the `cmd/gomodguard/v` prefix from `.Version` so local snapshot builds produce valid Docker tags (CI's GORELEASER_CURRENT_TAG override gives a clean version where the replace is a no-op)
- workflow: add docker/setup-qemu-action and docker/setup-buildx-action required for cross-arch builds on the amd64 runner
- Dockerfile: switch to gcr.io/distroless/static (~2MB vs ~350MB), use TARGETOS/TARGETARCH ARGs to pick the per-platform binary out of the multi-arch build context, and switch ENTRYPOINT to exec form since distroless has no shell