### PR TITLE
fix: preserve % characters in blocked module reasons and recommendations

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -24,9 +24,15 @@ const (
 	errParsingGoModFile = "unable to parse module file %s: %w"
 )
 
+// packageNamePlaceholder is substituted with the imported package path when an
+// issue is reported. Using a sentinel (rather than a fmt verb) keeps user-supplied
+// content — Reason text, recommendation names, error messages — safe to embed
+// verbatim, even when it contains `%` characters.
+const packageNamePlaceholder = "{{packageName}}"
+
 var (
-	blockReasonInBlockedList            = "import of package `%s` is blocked because the module is in the blocked modules list."
-	blockReasonHasLocalReplaceDirective = "import of package `%s` is blocked because the module has a local replace directive."
+	blockReasonInBlockedList            = "import of package `" + packageNamePlaceholder + "` is blocked because the module is in the blocked modules list."
+	blockReasonHasLocalReplaceDirective = "import of package `" + packageNamePlaceholder + "` is blocked because the module has a local replace directive."
 
 	// startsWithVersion is used to test when a string begins with the version identifier of a module,
 	// after having stripped the prefix base module name. IE "github.com/foo/bar/v2/baz" => "v2/baz"
@@ -285,7 +291,7 @@ func (p *Processor) SetBlockedModules() { //nolint:gocognit // Ack this is a lon
 				// NOTE: Unreachable via real go.mod files; modfile.Parse rejects invalid versions
 				// earlier. Left untested by design as this branch cannot be triggered.
 				blockedModules[requiredModuleName] = append(blockedModules[requiredModuleName],
-					fmt.Sprintf("import of package `%%s` is blocked because the module version `%s` could not be parsed: %s",
+					fmt.Sprintf("import of package `"+packageNamePlaceholder+"` is blocked because the module version `%s` could not be parsed: %s",
 						requiredModuleVersion, err,
 					),
 				)
@@ -300,7 +306,7 @@ func (p *Processor) SetBlockedModules() { //nolint:gocognit // Ack this is a lon
 
 		if !isAllowed {
 			blockedModules[requiredModuleName] = append(blockedModules[requiredModuleName],
-				fmt.Sprintf("import of package `%%s` is blocked because %s", matchedButWrongVersion.NotAllowedReason(requiredModuleVersion)))
+				"import of package `"+packageNamePlaceholder+"` is blocked because "+matchedButWrongVersion.NotAllowedReason(requiredModuleVersion))
 		}
 	}
 
@@ -397,7 +403,7 @@ func (p *Processor) isBlockedPackageFromModFile(packageName string) []string {
 			formattedReasons := make([]string, 0, len(blockReasons))
 
 			for _, blockReason := range blockReasons {
-				formattedReasons = append(formattedReasons, fmt.Sprintf(blockReason, packageName))
+				formattedReasons = append(formattedReasons, strings.ReplaceAll(blockReason, packageNamePlaceholder, packageName))
 			}
 
 			return formattedReasons

--- a/processor_test.go
+++ b/processor_test.go
@@ -239,6 +239,27 @@ func TestProcessorProcessFiles(t *testing.T) { //nolint:funlen
 			},
 			wantEmpty: true,
 		},
+		"reason and recommendation containing percent characters are preserved verbatim": {
+			exampleDir: "examples/alloptions",
+			config: &gomodguard.Configuration{
+				Blocked: gomodguard.Blocked{
+					{
+						Module:          "github.com/uudashr/go-module",
+						MatchType:       gomodguard.ExactMatch,
+						Recommendations: []string{"golang.org/x/mod"},
+						Reason:          "see https://example.com/foo?x=100% and use %s instead",
+					},
+				},
+			},
+			wantReasons: []string{
+				"blocked_example.go:8:1 import of package `github.com/uudashr/go-module` is blocked because the " +
+					"module is in the blocked modules list. `golang.org/x/mod` is a recommended module. " +
+					"see https://example.com/foo?x=100% and use %s instead.",
+			},
+			notWantReasons: []string{
+				"%!", // fmt.Sprintf failure markers like %!s(MISSING) or %!.(MISSING)
+			},
+		},
 		"precedence - longest prefix wins over shorter prefix": {
 			exampleDir: "examples/alloptions",
 			config: &gomodguard.Configuration{


### PR DESCRIPTION
## Summary
- Block reasons containing `%` characters (URLs like `?x=100%`, prose like `use %s instead`, encoded chars) were silently mangled into `%!s(MISSING)` output, making the reason and recommendation text appear missing to library consumers.
- Root cause: user-supplied `Reason` and recommendation strings were concatenated into a stored template that was later passed as a `fmt.Sprintf` format string to inject the imported package path — so a second format-verb pass interpreted any `%` in user content.
- Fix: replace the deferred `%s` placeholder with a `{{packageName}}` sentinel resolved via `strings.ReplaceAll`, so user content is embedded verbatim and never re-parsed.

## Test plan
- [x] `go test ./...` passes
- [x] New regression test (`reason and recommendation containing percent characters are preserved verbatim`) exercises both `100%` and a literal `%s` in `Reason`, asserting the text survives and that no `%!` markers leak into the issue output
- [x] Verified the new test fails on the pre-fix code and passes after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)